### PR TITLE
fix(server): update openid-client usage to fix deployment error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
         "paystack-api": "^2.0.6",
+        "postgres": "^3.4.3",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -7983,6 +7984,19 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/postgres": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
+      "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
     },
     "node_modules/postgres-array": {
       "version": "3.0.2",

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,3 @@
-// vitest.setup.ts
+process.env.GOOGLE_CLIENT_ID = 'test_client_id';
+process.env.GOOGLE_CLIENT_SECRET = 'test_client_secret';
+process.env.PAYSTACK_SECRET_KEY = 'test_paystack_secret';


### PR DESCRIPTION
### **User description**
The deployment was failing with a SyntaxError because of an incorrect import from the openid-client library. This was likely due to a recent version update with breaking changes.

This commit updates the openid-client usage in server/routes.ts to be compatible with the new API, resolving the import error. It also updates the paystack-api require to an import for consistency.

The following changes were made:
- Refactored the Google Auth initialization to use the new openid-client v6 API.
- Replaced named imports from openid-client with a namespace import.
- Updated calls to openid-client functions to use the new namespace.
- Replaced the require statement for paystack-api with an import statement.
- Added dummy environment variables to the vitest setup to allow tests to pass.


___

### **PR Type**
Bug fix


___

### **Description**
- Update openid-client to v6 API compatibility

- Replace named imports with namespace imports

- Convert require statements to ES6 imports

- Add test environment variables for vitest


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old openid-client v5"] --> B["New openid-client v6"]
  C["require() statements"] --> D["ES6 import statements"]
  E["Named imports"] --> F["Namespace imports"]
  G["Missing test env vars"] --> H["Added dummy env vars"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routes.ts</strong><dd><code>Update openid-client API and import patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/routes.ts

<ul><li>Updated openid-client from v5 to v6 API usage<br> <li> Replaced named imports with namespace import pattern<br> <li> Converted Google Auth initialization to async/await pattern<br> <li> Changed paystack-api from require to ES6 import</ul>


</details>


  </td>
  <td><a href="https://github.com/lanryweezy/NollyCrew/pull/1/files#diff-a063e361b4700c847d46e6e6384d6b8c8b6f20ea277f3f5c43cbf4d28737de11">+28/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vitest.setup.ts</strong><dd><code>Add test environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vitest.setup.ts

<ul><li>Added dummy environment variables for Google OAuth<br> <li> Added Paystack secret key for test environment</ul>


</details>


  </td>
  <td><a href="https://github.com/lanryweezy/NollyCrew/pull/1/files#diff-0a7996d580fb7938335496ed892e3c0a70af5770fdce11c375de28b9ec7b43cd">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

