### PR TITLE
🎨 Palette: Add aria-label to options button in ProjectCard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing ARIA Labels on Options Buttons
+**Learning:** Icon-only buttons used for extra actions (like `<MoreVertical />` options buttons) in lists/cards often lack `aria-label`s, rendering them completely opaque to screen reader users.
+**Action:** When creating or reviewing components with card or list layouts, proactively ensure all icon-only action buttons (especially those common ones like "edit", "delete", or "options") have descriptive `aria-label`s.

--- a/client/src/components/ProjectCard.tsx
+++ b/client/src/components/ProjectCard.tsx
@@ -109,7 +109,7 @@ export default function ProjectCard({
               </div>
             </div>
           </div>
-          <Button variant="ghost" size="icon" data-testid={`button-options-${id}`}>
+          <Button variant="ghost" size="icon" data-testid={`button-options-${id}`} aria-label="Project options">
             <MoreVertical className="w-4 h-4" />
           </Button>
         </div>


### PR DESCRIPTION
I have completed a micro-UX improvement by adding an `aria-label` to the `MoreVertical` icon-only button in the `ProjectCard` component. This helps screen reader users understand the purpose of the options button. I've also recorded this in Palette's journal.

---
*PR created automatically by Jules for task [10931696190967074645](https://jules.google.com/task/10931696190967074645) started by @lanryweezy*