### PR TITLE
🎨 Palette: Improve accessibility of Navigation icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,1 @@
-## 2024-05-18 - Missing ARIA Labels on Options Buttons
-**Learning:** Icon-only buttons used for extra actions (like `<MoreVertical />` options buttons) in lists/cards often lack `aria-label`s, rendering them completely opaque to screen reader users.
-**Action:** When creating or reviewing components with card or list layouts, proactively ensure all icon-only action buttons (especially those common ones like "edit", "delete", or "options") have descriptive `aria-label`s.
+## 2024-04-28 - ARIA Labels for Navigation Icons\n**Learning:** Icon-only navigation buttons must always include aria-label attributes to ensure they are accessible via screen readers.\n**Action:** Will systematically verify and add aria-labels whenever creating or reviewing icon-only buttons.

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -208,6 +208,7 @@ export default function Navigation({
                   size="icon"
                   onClick={() => setIsSearchOpen(true)}
                   data-testid="button-search"
+                  aria-label="Search"
                   className="relative"
                 >
                   <Search className="w-4 h-4" />
@@ -228,6 +229,7 @@ export default function Navigation({
                       size="icon" 
                       className="relative"
                       data-testid="button-notifications"
+                      aria-label="Notifications"
                     >
                       <Bell className="w-4 h-4" />
                       {notifications > 0 && (
@@ -248,6 +250,7 @@ export default function Navigation({
                   size="icon" 
                   className="relative hidden sm:flex"
                   data-testid="button-messages"
+                  aria-label="Messages"
                 >
                   <MessageCircle className="w-4 h-4" />
                   {messages > 0 && (
@@ -340,6 +343,7 @@ export default function Navigation({
               className="md:hidden"
               onClick={() => setIsMobileMenuOpen(true)}
               data-testid="button-mobile-menu"
+              aria-label="Toggle mobile menu"
             >
               <Menu className="w-4 h-4" />
             </Button>


### PR DESCRIPTION
Added descriptive `aria-label` attributes to four icon-only buttons (`Search`, `Notifications`, `Messages`, `Menu`) within the `Navigation` component. This ensures screen readers can announce the purpose of these interactive elements, providing a more accessible user experience. The changes are purely additive to the DOM and rely on existing components.

---
*PR created automatically by Jules for task [12499678408697525532](https://jules.google.com/task/12499678408697525532) started by @lanryweezy*