### PR TITLE
🎨 Palette: Add Tooltip to ThemeToggle

### DIFF
--- a/client/src/components/ThemeToggle.tsx
+++ b/client/src/components/ThemeToggle.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Moon, Sun } from "lucide-react";
+import ResponsiveTooltip from "./ResponsiveTooltip";
 
 export default function ThemeToggle() {
   const [isDark, setIsDark] = useState(false);
@@ -36,18 +37,20 @@ export default function ThemeToggle() {
   };
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      onClick={toggleTheme}
-      data-testid="button-theme-toggle"
-      aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}
-    >
-      {isDark ? (
-        <Sun className="h-4 w-4" />
-      ) : (
-        <Moon className="h-4 w-4" />
-      )}
-    </Button>
+    <ResponsiveTooltip content={`Switch to ${isDark ? 'light' : 'dark'} mode`}>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={toggleTheme}
+        data-testid="button-theme-toggle"
+        aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}
+      >
+        {isDark ? (
+          <Sun className="h-4 w-4" />
+        ) : (
+          <Moon className="h-4 w-4" />
+        )}
+      </Button>
+    </ResponsiveTooltip>
   );
 }


### PR DESCRIPTION
💡 **What**: Added a `ResponsiveTooltip` component to wrap the existing `ThemeToggle` icon-only button.
🎯 **Why**: The `ThemeToggle` component is an icon-only button that previously lacked visible context on hover or focus for sighted users. This improves usability by clarifying the action ("Switch to light/dark mode") before the user interacts with it.
📸 **Before/After**: The button now displays a tooltip dynamically mirroring its current `aria-label` when hovered.
♿ **Accessibility**: Enhanced clarity for sighted users and keyboard navigators through standard tooltip behaviors (focus/hover states), supporting the existing `aria-label`.

---
*PR created automatically by Jules for task [4625140180980512502](https://jules.google.com/task/4625140180980512502) started by @lanryweezy*