### PR TITLE
🎨 Palette: Add ARIA labels to Messages icon buttons

### DIFF
--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -105,7 +105,7 @@ export default function Messages() {
               <div className="p-4 border-b space-y-4">
                 <div className="flex items-center justify-between">
                   <h2 className="text-xl font-bold">Messages</h2>
-                  <Button variant="ghost" size="icon" className="rounded-full">
+                  <Button variant="ghost" size="icon" className="rounded-full" aria-label="New chat">
                     <UserPlus className="h-5 w-5" />
                   </Button>
                 </div>
@@ -177,10 +177,10 @@ export default function Messages() {
                     </div>
                   </div>
                   <div className="flex items-center gap-1">
-                    <Button variant="ghost" size="icon" className="text-muted-foreground"><Phone className="h-4 w-4" /></Button>
-                    <Button variant="ghost" size="icon" className="text-muted-foreground"><Video className="h-4 w-4" /></Button>
-                    <Button variant="ghost" size="icon" className="text-muted-foreground"><Info className="h-4 w-4" /></Button>
-                    <Button variant="ghost" size="icon" className="text-muted-foreground"><MoreVertical className="h-4 w-4" /></Button>
+                    <Button variant="ghost" size="icon" className="text-muted-foreground" aria-label="Start voice call"><Phone className="h-4 w-4" /></Button>
+                    <Button variant="ghost" size="icon" className="text-muted-foreground" aria-label="Start video call"><Video className="h-4 w-4" /></Button>
+                    <Button variant="ghost" size="icon" className="text-muted-foreground" aria-label="Chat info"><Info className="h-4 w-4" /></Button>
+                    <Button variant="ghost" size="icon" className="text-muted-foreground" aria-label="More options"><MoreVertical className="h-4 w-4" /></Button>
                   </div>
                 </div>
 


### PR DESCRIPTION
🎨 Palette: Added ARIA labels to icon-only buttons in Messages page

💡 **What:** Added descriptive `aria-label` attributes to the five icon-only buttons in the Messages chat interface (`UserPlus`, `Phone`, `Video`, `Info`, `MoreVertical`).
🎯 **Why:** To ensure screen reader users can navigate and understand the purpose of the actions available in the chat interface, following accessibility best practices.
♿ **Accessibility:** This ensures that elements without text content are properly announced by assistive technologies.

---
*PR created automatically by Jules for task [5302878079225492452](https://jules.google.com/task/5302878079225492452) started by @lanryweezy*