### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-05-19 - Added ARIA labels to Utility Dashboard Icons
 **Learning:** Found multiple instances where utility icon-only buttons (like edit, delete, and navigation arrows) within dashboard components (e.g. `ResourceAllocation`, `RiskManagementDashboard`, `GanttChart`) were missing `aria-label`s. Because these lists of items map to similar buttons, it's crucial to provide context-aware labels (e.g., "Delete resource X") rather than generic ones.
 **Action:** When creating or reviewing lists or cards with action buttons in dashboard components, ensure all icon-only `Button size="icon"` elements have descriptive and context-aware `aria-label`s.
+## 2024-05-24 - Accessibility pattern: Dynamic Aria Labels
+**Learning:** Found a recurring pattern in VideoCall and VirtualDirectorChat where icon-only buttons toggle states (e.g. mic on/off, video on/off). It is not enough to just add a static label; the label must dynamically update to reflect the current actionable state (e.g., `aria-label={isMuted ? "Unmute" : "Mute"}`). This provides much clearer context to screen reader users than a static "Toggle Mute" label.
+**Action:** When adding `aria-label` to state-toggling icon buttons, use a ternary operator to make the label dynamically reflect the action that will happen when clicked, rather than a generic toggle description.

--- a/client/src/components/Notifications.tsx
+++ b/client/src/components/Notifications.tsx
@@ -160,6 +160,7 @@ export default function Notifications() {
                         size="icon" 
                         className="h-5 w-5 ml-2"
                         onClick={() => clearNotification(notification.id)}
+                        aria-label="Clear notification"
                       >
                         <X className="w-3 h-3" />
                       </Button>

--- a/client/src/components/ProfileCard.tsx
+++ b/client/src/components/ProfileCard.tsx
@@ -149,6 +149,7 @@ export default function ProfileCard({
           size="icon"
           onClick={onViewProfile}
           data-testid={`button-view-${id}`}
+          aria-label="View profile"
         >
           <Eye className="w-4 h-4" />
         </Button>

--- a/client/src/components/RealTimeChat.tsx
+++ b/client/src/components/RealTimeChat.tsx
@@ -149,6 +149,7 @@ export default function RealTimeChat({ projectId, channelId, users }: RealTimeCh
               onClick={handleSendMessage}
               disabled={!newMessage.trim()}
               size="icon"
+              aria-label="Send message"
             >
               <Send className="w-4 h-4" />
             </Button>

--- a/client/src/components/VideoCall.tsx
+++ b/client/src/components/VideoCall.tsx
@@ -165,6 +165,7 @@ export default function VideoCall({ targetUserId, onClose, isIncoming, incomingO
               size="icon" 
               className="rounded-full w-12 h-12"
               onClick={toggleMute}
+              aria-label={isMuted ? "Unmute" : "Mute"}
             >
               {isMuted ? <MicOff /> : <Mic />}
             </Button>
@@ -174,6 +175,7 @@ export default function VideoCall({ targetUserId, onClose, isIncoming, incomingO
               size="icon" 
               className="rounded-full w-12 h-12"
               onClick={toggleVideo}
+              aria-label={isVideoOff ? "Turn on video" : "Turn off video"}
             >
               {isVideoOff ? <VideoOff /> : <Video />}
             </Button>
@@ -183,6 +185,7 @@ export default function VideoCall({ targetUserId, onClose, isIncoming, incomingO
               size="icon" 
               className="rounded-full w-14 h-14"
               onClick={endCall}
+              aria-label="End call"
             >
               <PhoneOff className="fill-current" />
             </Button>
@@ -191,6 +194,7 @@ export default function VideoCall({ targetUserId, onClose, isIncoming, incomingO
               variant="secondary" 
               size="icon" 
               className="rounded-full w-12 h-12"
+              aria-label="Maximize video"
             >
               <Maximize2 />
             </Button>

--- a/client/src/components/VirtualDirectorChat.tsx
+++ b/client/src/components/VirtualDirectorChat.tsx
@@ -107,7 +107,7 @@ export default function VirtualDirectorChat() {
           </div>
           <div className="flex gap-2">
             <Badge variant="outline" className="bg-background/50 backdrop-blur-sm">Nollywood Expert</Badge>
-            <Button variant="ghost" size="icon" className="h-8 w-8">
+            <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="More options">
               <MoreHorizontal className="h-4 w-4" />
             </Button>
           </div>
@@ -200,7 +200,7 @@ export default function VirtualDirectorChat() {
                 className="pr-10 h-11 rounded-xl focus-visible:ring-primary/20 transition-all border-primary/10 shadow-inner"
               />
               <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
-                <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-primary">
+                <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-primary" aria-label="Use microphone">
                   <Mic className="h-4 w-4" />
                 </Button>
               </div>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to various icon-only `<Button>` components (`Notifications`, `ProfileCard`, `RealTimeChat`, `VideoCall`, `VirtualDirectorChat`).
🎯 Why: To improve screen reader accessibility and ensure all interactive elements have text alternatives, especially dynamic ones like mute/unmute toggles.
♿ Accessibility: Ensures assistive technologies can announce the purpose of the buttons. Added dynamic labels where state changes.

---
*PR created automatically by Jules for task [2805015185212433704](https://jules.google.com/task/2805015185212433704) started by @lanryweezy*