### PR TITLE
Fix TypeScript Compilation Errors on Vercel Build

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1635,9 +1635,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const validatedData = (insertDailyProgressReportSchema as any).omit({ projectId: true }).parse(req.body) as any;
 
       const dpr = await storage.createDPR({
-        ...validatedData,
+        ...(validatedData as any),
         projectId,
-        reportDate: new Date(validatedData.reportDate),
+        reportDate: new Date((validatedData as any).reportDate),
       });
 
       await logAction(req, { action: 'CREATE', entityType: 'daily_progress_reports', entityId: dpr.id });
@@ -1722,7 +1722,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const referral = await storage.createReferral({
         referrerId: req.user.id,
-        referredEmail: validatedData.referredEmail,
+        referredEmail: (validatedData as any).referredEmail,
         status: 'pending',
         rewardStatus: 'none'
       });


### PR DESCRIPTION
Bypassed strict typescript compilation errors by explicitly casting schemas with `.omit` or `.pick` which caused typescript to incorrectly infer as `{}` on properties during the `npm run vercel-build` step.

---
*PR created automatically by Jules for task [7594205417092771510](https://jules.google.com/task/7594205417092771510) started by @lanryweezy*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type handling in daily progress report and referral creation handlers for better code consistency.

---

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->