### PR TITLE
🔒 Fix insecure in-memory storage of password reset tokens

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,4 @@
 **Vulnerability:** Use of `Math.random().toString(36).substring(2, 11)` for generating entity IDs in `MemStorage`. `Math.random()` is not cryptographically secure and can lead to predictable IDs, enabling enumeration or collision attacks.
 **Learning:** In-memory storage implementations often use simple random strings for convenience, but these shortcuts compromise security in systems where IDs are used for access control or object referencing. UUIDs provide a standardized, collision-resistant, and cryptographically secure alternative.
 **Prevention:** Always use `crypto.randomUUID()` or a similar CSPRNG (Cryptographically Secure Pseudo-Random Number Generator) for generating identifiers. Avoid `Math.random()` for any security-sensitive application, including ID generation, session tokens, or password resets.
+- Added InsertPasswordResetToken schema to address TypeScript compilation failures for db table inserts

--- a/logs/2026-08-12.log
+++ b/logs/2026-08-12.log
@@ -1,0 +1,7 @@
+{"timestamp":"2026-08-12T16:52:50.218Z","level":"info","message":"Using MemStorage (In-memory storage)"}
+{"timestamp":"2026-08-12T16:52:53.826Z","level":"info","message":"Using MemStorage (In-memory storage)"}
+{"timestamp":"2026-08-12T16:53:56.925Z","level":"info","message":"Using MemStorage (In-memory storage)"}
+{"timestamp":"2026-08-12T16:56:04.057Z","level":"info","message":"Using MemStorage (In-memory storage)"}
+{"timestamp":"2026-08-12T16:59:06.211Z","level":"info","message":"Using MemStorage (In-memory storage)"}
+{"timestamp":"2026-08-12T17:00:18.459Z","level":"info","message":"Using MemStorage (In-memory storage)"}
+{"timestamp":"2026-08-12T17:01:56.772Z","level":"info","message":"Using MemStorage (In-memory storage)"}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -266,11 +266,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       const resetToken = crypto.randomBytes(32).toString('hex');
-      const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString(); // 1 hour
+      const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
 
-      // Store token (in-memory for demo)
-      if (!(global as any).__passwordResets) (global as any).__passwordResets = new Map();
-      (global as any).__passwordResets.set(resetToken, { userId: user.id, expiresAt });
+      if (storage.createPasswordResetToken) {
+        await storage.createPasswordResetToken({
+          userId: user.id,
+          token: resetToken,
+          expiresAt: expiresAt,
+        });
+      }
 
       // Send reset email
       const clientUrl = process.env.CLIENT_URL || 'http://localhost:5000';
@@ -282,7 +286,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         await sendEmail({
           to: user.email,
           subject: 'Reset your NollyCrew password',
-          html: generatePasswordResetEmail({ userName: `${user.firstName} ${user.lastName}`, resetLink, expiresAt }),
+          html: generatePasswordResetEmail({ userName: `${user.firstName} ${user.lastName}`, resetLink, expiresAt: expiresAt.toISOString() }),
         });
       } catch {}
 
@@ -297,18 +301,21 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const { token, newPassword } = req.body;
       if (!token || !newPassword) return res.status(400).json({ error: 'Token and new password are required' });
 
-      const resets = (global as any).__passwordResets || new Map();
-      const resetData = resets.get(token);
+      if (!storage.getPasswordResetToken || !storage.deletePasswordResetToken) {
+        return res.status(500).json({ error: 'Internal server error' });
+      }
+
+      const resetData = await storage.getPasswordResetToken(token);
       
       if (!resetData) return res.status(400).json({ error: 'Invalid or expired reset token' });
       if (new Date(resetData.expiresAt) < new Date()) {
-        resets.delete(token);
+        await storage.deletePasswordResetToken(token);
         return res.status(400).json({ error: 'Reset token has expired' });
       }
 
       const passwordHash = await bcrypt.hash(newPassword, 10);
       await storage.updateUser(resetData.userId, { passwordHash } as any);
-      resets.delete(token);
+      await storage.deletePasswordResetToken(token);
 
       res.json({ ok: true, message: 'Password reset successful. You can now login.' });
     } catch (error) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -34,6 +34,8 @@ import {
   type InsertSupportTicket,
   type Referral,
   type InsertReferral,
+  type PasswordResetToken,
+  type InsertPasswordResetToken,
   users,
   userRoles,
   projects,
@@ -50,7 +52,8 @@ import {
   kycVerifications,
   dailyProgressReports,
   supportTickets,
-  referrals
+  referrals,
+  passwordResetTokens
 } from "../shared/schema.js";
 import { db } from "./db.js";
 import { eq, and, desc, count, ilike } from "drizzle-orm";
@@ -165,6 +168,11 @@ export interface IStorage {
   getBookmarks?(userId: string): Promise<any[]>;
   createBookmark?(bookmark: any): Promise<any>;
   deleteBookmark?(userId: string, jobId: string): Promise<boolean>;
+
+  // Password Reset Tokens
+  createPasswordResetToken?(token: InsertPasswordResetToken): Promise<PasswordResetToken>;
+  getPasswordResetToken?(tokenStr: string): Promise<PasswordResetToken | undefined>;
+  deletePasswordResetToken?(tokenStr: string): Promise<boolean>;
 }
 
 export class DbStorage implements IStorage {
@@ -588,6 +596,22 @@ export class DbStorage implements IStorage {
       user: userProfile ? { id: userProfile.id, email: userProfile.email, firstName: userProfile.firstName, lastName: userProfile.lastName } : null,
     };
   }
+
+  async createPasswordResetToken(token: InsertPasswordResetToken): Promise<PasswordResetToken> {
+    const [newToken] = await db!.insert(passwordResetTokens).values(token as any).returning();
+    return newToken;
+  }
+
+  async getPasswordResetToken(tokenStr: string): Promise<PasswordResetToken | undefined> {
+    return await db!.query.passwordResetTokens.findFirst({
+      where: eq(passwordResetTokens.token, tokenStr),
+    });
+  }
+
+  async deletePasswordResetToken(tokenStr: string): Promise<boolean> {
+    const [deleted] = await db!.delete(passwordResetTokens).where(eq(passwordResetTokens.token, tokenStr)).returning();
+    return !!deleted;
+  }
 }
 
 export class MemStorage implements IStorage {
@@ -608,6 +632,7 @@ export class MemStorage implements IStorage {
   private dailyProgressReports = new Map<string, DailyProgressReport>();
   private supportTickets = new Map<string, SupportTicket>();
   private referrals = new Map<string, Referral>();
+  private passwordResetTokens = new Map<string, PasswordResetToken>();
 
   async getUser(id: string): Promise<User | undefined> {
     return this.users.get(id);
@@ -1293,6 +1318,27 @@ export class MemStorage implements IStorage {
 
   async deleteBookmark(userId: string, jobId: string): Promise<boolean> {
     return this.bookmarks.delete(`${userId}-${jobId}`);
+  }
+
+  async createPasswordResetToken(token: InsertPasswordResetToken): Promise<PasswordResetToken> {
+    const id = Date.now().toString();
+    const newToken: PasswordResetToken = {
+      id,
+      userId: token.userId,
+      token: token.token,
+      expiresAt: new Date(token.expiresAt as string | number | Date),
+      createdAt: new Date(),
+    };
+    this.passwordResetTokens.set(token.token, newToken);
+    return newToken;
+  }
+
+  async getPasswordResetToken(tokenStr: string): Promise<PasswordResetToken | undefined> {
+    return this.passwordResetTokens.get(tokenStr);
+  }
+
+  async deletePasswordResetToken(tokenStr: string): Promise<boolean> {
+    return this.passwordResetTokens.delete(tokenStr);
   }
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -3,6 +3,19 @@ import { pgTable, text, varchar, timestamp, integer, decimal, jsonb, boolean, pr
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+// Password reset tokens for account recovery
+export const passwordResetTokens = pgTable("password_reset_tokens", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  userId: varchar("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+  token: text("token").notNull().unique(),
+  expiresAt: timestamp("expires_at").notNull(),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+}, (table) => {
+  return {
+    tokenIdx: index("password_reset_tokens_idx").on(table.token),
+  };
+});
+
 // Waitlist table for collecting early-access emails
 export const waitlist = pgTable("waitlist", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
@@ -500,6 +513,10 @@ export type SupportTicket = typeof supportTickets.$inferSelect;
 export type InsertSupportTicket = z.infer<typeof insertSupportTicketSchema>;
 export type Referral = typeof referrals.$inferSelect;
 export type InsertReferral = z.infer<typeof insertReferralSchema>;
+
+export const insertPasswordResetTokenSchema = createInsertSchema(passwordResetTokens);
+export type PasswordResetToken = typeof passwordResetTokens.$inferSelect;
+export type InsertPasswordResetToken = typeof passwordResetTokens.$inferInsert;
 
 // Invitations table for project member invites via email/phone
 export const invitations = pgTable("invitations", {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Password reset tokens were previously stored in a global in-memory `Map` (`global.__passwordResets`).

⚠️ **Risk:** The potential impact if left unfixed
Tokens would be lost whenever the server process restarts (common in serverless platforms like Vercel or ephemeral deployments on Render). Furthermore, in a multi-instance production environment, if a user requests a reset on Instance A but the follow-up request hits Instance B, the reset will unexpectedly fail. This creates an unreliable recovery mechanism and could lead to account lockouts.

🛡️ **Solution:** How the fix addresses the vulnerability
This fix introduces a `password_reset_tokens` table in the PostgreSQL database using Drizzle ORM. Tokens are now persistently stored with an expiration timestamp and a foreign key constraint linked to the user. The API routes `/api/auth/request-password-reset` and `/api/auth/reset-password` have been updated to utilize the new database-backed storage methods, ensuring robust token tracking and reliable account recovery across any multi-instance or serverless setup.

---
*PR created automatically by Jules for task [10612377924789643532](https://jules.google.com/task/10612377924789643532) started by @lanryweezy*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password reset reliability by securely persisting reset tokens.
  * Password reset tokens now expire correctly and are removed after use or expiration.
  * Added safeguards for unavailable token storage configuration.
* **Data Management**
  * Added support for storing password reset tokens across database-backed and in-memory environments.
  * Tokens are automatically removed when their associated account is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->