### PR TITLE
🤖 Astra: Fix silent parsing failures on markdown-wrapped JSON

### DIFF
--- a/.jules/astra.md
+++ b/.jules/astra.md
@@ -1,3 +1,7 @@
 ## 2026-08-12 - JSON Object vs Array Mismatch in response_format
 **Learning:** When using OpenAI's `response_format: { type: "json_object" }`, the prompt must explicitly request a JSON object (e.g., `{ "arc": [...] }`), not a raw JSON array. Requesting an array causes an API contradiction that can lead to unexpected model refusals or malformed output. Additionally, raw `JSON.parse` on AI responses without try/catch creates silent failure risks that crash the application.
 **Action:** Always ensure the prompt aligns with the requested output schema, and wrap all `JSON.parse(completion)` calls in a `try/catch` with structural validation (e.g., `Array.isArray(parsed.arc)`) and a graceful fallback.
+
+## 2026-08-14 - Silent Failures from Markdown-wrapped JSON
+**Learning:** When using models without \`response_format: { type: "json_object" }\` (like standard gpt-4), they often wrap JSON outputs in markdown formatting (e.g., \`\`\`json ... \`\`\`). Raw \`JSON.parse(completion)\` throws a \`SyntaxError\` on this formatting, causing the application to silently crash or fall back to mock data unexpectedly.
+**Action:** Always parse AI JSON responses using a safe wrapper that strips markdown backticks and catches parsing errors. Use \`content.replace(/^```(?:json)?\\n?/i, "").replace(/\\n?```$/i, "").trim()\` before calling \`JSON.parse\`.

--- a/server/ai-enhanced.ts
+++ b/server/ai-enhanced.ts
@@ -6,6 +6,18 @@ const openai = process.env.OPENAI_API_KEY ? new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 }) : null;
 
+// AI Quality: Helper to safely parse JSON from model responses, handling markdown wrappers
+function safeParseAIJSON<T>(content: string): T | null {
+  try {
+    // Strip markdown formatting if present (e.g., ```json\n...\n```)
+    const cleaned = content.replace(/^```(?:json)?\n?/i, '').replace(/\n?```$/i, '').trim();
+    return JSON.parse(cleaned) as T;
+  } catch (e) {
+    console.warn('AI Quality: Failed to parse JSON response', e);
+    return null;
+  }
+}
+
 export interface EnhancedScriptAnalysis {
   scenes: number;
   sceneList: Array<{
@@ -249,8 +261,11 @@ ${scriptText.substring(0, 8000)} // Limit to avoid token limits
       throw new Error('No response from OpenAI');
     }
 
-    // Parse JSON response
-    const analysis = JSON.parse(response);
+    // Parse JSON response safely
+    const analysis = safeParseAIJSON<any>(response);
+    if (!analysis) {
+      throw new Error('Failed to parse AI response as valid JSON');
+    }
     
     // Add analyzedAt timestamp
     analysis.analyzedAt = new Date().toISOString();
@@ -494,7 +509,12 @@ Optimize for:
       throw new Error('No response from OpenAI');
     }
 
-    return JSON.parse(response);
+    const optimization = safeParseAIJSON<EnhancedScheduleOptimization>(response);
+    if (!optimization) {
+      throw new Error('Failed to parse schedule optimization as valid JSON');
+    }
+
+    return optimization;
     
   } catch (error) {
     console.error('Enhanced schedule optimization error:', error);
@@ -602,7 +622,12 @@ Return JSON with:
       throw new Error('No response from OpenAI');
     }
 
-    return JSON.parse(response);
+    const marketingContent = safeParseAIJSON<any>(response);
+    if (!marketingContent) {
+      throw new Error('Failed to parse marketing content as valid JSON');
+    }
+
+    return marketingContent;
     
   } catch (error) {
     console.error('Enhanced marketing content generation error:', error);


### PR DESCRIPTION
💡 What: Introduced `safeParseAIJSON` helper function to handle raw AI model responses and strip markdown wrapping.
🎯 Why: Models like gpt-4 often wrap their JSON outputs with ` ```json ` and ` ``` ` if not explicitly using `response_format: { type: "json_object" }`. Raw `JSON.parse` crashes on these responses, silently degrading the application.
📊 Impact: Eliminates silent JSON parse crashes and unexpected fallbacks to mock data.
🔬 Verification: Run `pnpm test` (or typescript compiler check) and spot check `analyzeScriptWithAI`, `optimizeEnhancedScheduleWithAI`, and `generateEnhancedMarketingContent`.

---
*PR created automatically by Jules for task [13793351461861413302](https://jules.google.com/task/13793351461861413302) started by @lanryweezy*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when processing AI-generated analysis, schedules, and marketing content.
  - Responses wrapped in Markdown code fences are now handled correctly.
  - Invalid or unreadable AI responses produce clearer errors while preserving existing fallback behavior.
- **Documentation**
  - Added guidance for safely handling structured AI responses and parsing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->