### PR TITLE
🤖 Astra: Fix silent AI parsing failures via markdown stripping

### DIFF
--- a/.jules/astra.md
+++ b/.jules/astra.md
@@ -5,3 +5,7 @@
 ## 2026-08-14 - Silent Failures from Markdown-wrapped JSON
 **Learning:** When using models without \`response_format: { type: "json_object" }\` (like standard gpt-4), they often wrap JSON outputs in markdown formatting (e.g., \`\`\`json ... \`\`\`). Raw \`JSON.parse(completion)\` throws a \`SyntaxError\` on this formatting, causing the application to silently crash or fall back to mock data unexpectedly.
 **Action:** Always parse AI JSON responses using a safe wrapper that strips markdown backticks and catches parsing errors. Use \`content.replace(/^```(?:json)?\\n?/i, "").replace(/\\n?```$/i, "").trim()\` before calling \`JSON.parse\`.
+
+## 2026-08-14 - Robust AI JSON Output Parsing Strategy
+**Learning:** Standard AI output parsing using regex to strip markdown (e.g. `^```json`) can fail if the model includes a conversational preamble (e.g., "Here is your JSON..."). This results in a parsing crash or fallback. Wait, actually, `JSON.parse` is very strict. The current regex `content.replace(/^```(?:json)?\n?/i, '').replace(/\n?```$/i, '').trim()` anchors to the start (`^`) and end (`$`), making it fail if there is any preamble or postamble.
+**Action:** When parsing AI responses for JSON, a more resilient pattern might be needed if models regularly output preambles, or we must use strict prompt engineering (`return ONLY valid JSON matching this schema... Do not include markdown, preamble, or explanation.`). Given the strict prompts in this repo, the `^...$` approach usually suffices, but we must ensure we don't accidentally modify un-staged junk files.

--- a/server/ai-advanced.ts
+++ b/server/ai-advanced.ts
@@ -112,7 +112,9 @@ export async function analyzeSentiment(scriptText: string): Promise<any> {
     const content = response.choices[0]?.message?.content || '{"arc": []}';
     let parsed;
     try {
-      parsed = JSON.parse(content);
+      // AI Quality: Strip markdown formatting if present to prevent silent parsing failures
+      const cleaned = content.replace(/^```(?:json)?\n?/i, '').replace(/\n?```$/i, '').trim();
+      parsed = JSON.parse(cleaned);
     } catch {
       console.warn('AI Quality: Failed to parse sentiment analysis JSON, falling back');
       return { arc: [] };
@@ -197,7 +199,9 @@ export async function predictFatigue(scheduleDays: any[]): Promise<any> {
     const content = response.choices[0]?.message?.content || '{"warnings": []}';
     let parsed;
     try {
-      parsed = JSON.parse(content);
+      // AI Quality: Strip markdown formatting if present to prevent silent parsing failures
+      const cleaned = content.replace(/^```(?:json)?\n?/i, '').replace(/\n?```$/i, '').trim();
+      parsed = JSON.parse(cleaned);
     } catch {
       console.warn('AI Quality: Failed to parse fatigue prediction JSON, falling back');
       return { warnings: [] };

--- a/server/ai.ts
+++ b/server/ai.ts
@@ -52,7 +52,9 @@ async function callOpenAIWithSchema<T>(options: {
     const response = completion.choices[0]?.message?.content;
     if (!response) throw new Error('No response from OpenAI');
 
-    const result = JSON.parse(response) as T;
+    // AI Quality: Strip markdown formatting if present to prevent parsing crashes
+    const cleanedResponse = response.replace(/^```(?:json)?\n?/i, '').replace(/\n?```$/i, '').trim();
+    const result = JSON.parse(cleanedResponse) as T;
     await setCache(cacheKey, result, options.ttl || 86400);
     return result;
   } catch (error) {


### PR DESCRIPTION
💡 **What**: Added regex to strip markdown wrappers from AI JSON responses before parsing in `server/ai.ts` and `server/ai-advanced.ts`.
🎯 **Why**: AI models frequently wrap their JSON output in standard markdown code blocks (e.g., ` ```json `). Using raw `JSON.parse()` on these strings throws a `SyntaxError`, which caused the system to crash or fail silently to mock data fallbacks, masking the actual success of the model's generation.
📊 **Impact**: Eliminates silent JSON parsing crashes from markdown wrapping, significantly improving the success rate of AI-driven features like script analysis and fatigue prediction.
🔬 **Verification**: Run `pnpm test` and verify that the AI parsing logic in tests passes without silent fallback errors due to syntax. All relevant tests for these modules pass.

---
*PR created automatically by Jules for task [7609667612771659919](https://jules.google.com/task/7609667612771659919) started by @lanryweezy*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AI response handling when JSON is wrapped in Markdown code fences.
  - Sentiment analysis and fatigue predictions now parse supported formatted responses more reliably.
  - Existing fallback behavior remains available for invalid or unexpected responses.

- **Documentation**
  - Added guidance on handling conversational text surrounding AI-generated JSON.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->