### PR TITLE
🤖 Astra: Add exponential backoff retries for OpenAI calls to prevent silent degradation

### DIFF
--- a/.jules/astra.md
+++ b/.jules/astra.md
@@ -15,3 +15,7 @@
 ## 2024-05-18 - Missing Timeout Guard for External AI Calls
 **Learning:** Unguarded AI API calls (like `openai.chat.completions.create` or `openai.embeddings.create`) can silently hang indefinitely when the model or network stalls. Without timeouts, the app doesn't hit our intended fallback mechanisms, causing poor UX and resource exhaustion.
 **Action:** Always use the OpenAI SDK's native `{ timeout: ms }` option on external AI API calls with correctly calibrated durations (e.g., 60-120s for completions, 15s for embeddings). This rejects the hanging connection to free up underlying server network resources and triggers the app's graceful fallback logic.
+
+## 2026-08-17 - Missing Retries for Batch Parallel AI Calls
+**Learning:** Unguarded parallel AI calls, especially `openai.embeddings.create` mapped over an array, are extremely vulnerable to rate limiting (HTTP 429). A single 429 error within a `Promise.all` fails the entire batch, immediately triggering the app's fallback logic (e.g. mock data generation) despite other network requests succeeding. This degrades feature quality silently.
+**Action:** Always wrap transient-prone AI API calls with a retry utility that utilizes exponential backoff with jitter. This is critical for both chat completions and embeddings, ensuring robust operation under load or network transient failures.

--- a/server/ai.ts
+++ b/server/ai.ts
@@ -7,6 +7,32 @@ export const openai = process.env.OPENAI_API_KEY ? new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 }) : null;
 
+// AI Quality: Add exponential backoff retry logic for transient API failures
+async function withAIRetry<T>(
+  operation: () => Promise<T>,
+  maxRetries: number = 3,
+  baseDelay: number = 1000
+): Promise<T> {
+  let attempt = 0;
+  while (true) {
+    try {
+      return await operation();
+    } catch (error: any) {
+      attempt++;
+      // Only retry on rate limits (429) or server errors (500+)
+      const isRetryable = !error?.status || error.status === 429 || error.status >= 500;
+      if (attempt > maxRetries || !isRetryable) {
+        throw error;
+      }
+      // Exponential backoff with jitter
+      const jitter = Math.random() * 200;
+      const delay = baseDelay * Math.pow(2, attempt - 1) + jitter;
+      console.warn(`AI Quality: API error ${error?.status || 'network'}, retrying attempt ${attempt}/${maxRetries} after ${Math.round(delay)}ms`);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+}
+
 // Helper to generate cache keys
 function generateCacheKey(prefix: string, content: any): string {
   const hash = crypto.createHash('sha256').update(JSON.stringify(content)).digest('hex');
@@ -32,7 +58,7 @@ async function callOpenAIWithSchema<T>(options: {
   if (cached) return cached;
 
   try {
-    const completion = await openai.chat.completions.create({
+    const completion = await withAIRetry(() => openai.chat.completions.create({
       model: options.model || "gpt-4o-2024-08-06",
       messages: [
         { role: "system", content: options.systemPrompt },
@@ -47,7 +73,7 @@ async function callOpenAIWithSchema<T>(options: {
         }
       },
       temperature: 0.1,
-    }, { timeout: 60000 });
+    }, { timeout: 60000 }));
 
     const response = completion.choices[0]?.message?.content;
     if (!response) throw new Error('No response from OpenAI');
@@ -375,10 +401,10 @@ export async function generateMarketingContent(
 async function getEmbedding(text: string): Promise<number[]> {
   if (!openai) return [];
   
-  const response = await openai.embeddings.create({
+  const response = await withAIRetry(() => openai.embeddings.create({
     model: "text-embedding-3-small",
     input: text
-  }, { timeout: 15000 });
+  }, { timeout: 15000 }));
   
   return response.data[0].embedding;
 }


### PR DESCRIPTION
🤖 **Astra: Add exponential backoff retries for OpenAI calls**

💡 **What:** The AI quality issue identified is the lack of retry logic on raw OpenAI network calls, particularly when dealing with parallel embedding calls or during temporary load/network spikes.
🎯 **Why:** The failure mode this addresses is silent feature degradation. For instance, when casting recommendations are requested for multiple actors simultaneously using `Promise.all(candidates.map(...))`, a single 429 Rate Limit error would fail the entire promise chain and cause the system to silently fallback to generating mock data, severely impacting the quality of the product.
📊 **Impact:** Eliminates silent feature degradation due to transient network or load issues. Improves overall feature resilience significantly without altering prompt complexity.
🔬 **Verification:** The unit test `server/__tests__/ai.test.ts` passes. The `withAIRetry` code explicitly handles backoff loops for 429s and 5xx errors and was manually verified using scratchpad logic.

---
*PR created automatically by Jules for task [16590261795418432954](https://jules.google.com/task/16590261795418432954) started by @lanryweezy*