### PR TITLE
🤖 Astra: Add retries to AI batch parallel calls

### DIFF
--- a/server/ai-advanced.ts
+++ b/server/ai-advanced.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai';
+import { withAIRetry } from './ai.js';
 
 const openai = process.env.OPENAI_API_KEY ? new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
@@ -61,7 +62,7 @@ export async function translateScript(scriptText: string, targetLanguage: 'Yorub
   }
 
   try {
-    const response = await openai.chat.completions.create({
+    const response = await withAIRetry(() => openai.chat.completions.create({
       model: "gpt-4o",
       messages: [
         {
@@ -74,7 +75,7 @@ export async function translateScript(scriptText: string, targetLanguage: 'Yorub
         }
       ],
       temperature: 0.3
-    }, { timeout: 60000 });
+    }, { timeout: 60000 }));
 
     return response.choices[0]?.message?.content || "Translation failed.";
   } catch (error) {
@@ -94,7 +95,7 @@ export async function analyzeSentiment(scriptText: string): Promise<any> {
     Return a JSON object containing an "arc" array. Each item in the array should represent a scene or story beat with:
     { "beat": "Name of the beat/scene", "tension": 1-10, "primaryEmotion": "Emotion" }`;
 
-    const response = await openai.chat.completions.create({
+    const response = await withAIRetry(() => openai.chat.completions.create({
       model: "gpt-4o",
       response_format: { type: "json_object" },
       messages: [
@@ -107,7 +108,7 @@ export async function analyzeSentiment(scriptText: string): Promise<any> {
           content: prompt + "\n\nScript:\n" + scriptText.substring(0, 10000)
         }
       ]
-    }, { timeout: 60000 });
+    }, { timeout: 60000 }));
 
     const content = response.choices[0]?.message?.content || '{"arc": []}';
     let parsed;
@@ -142,7 +143,7 @@ export async function generateReleaseForm(talentName: string, roleName: string, 
   }
 
   try {
-    const response = await openai.chat.completions.create({
+    const response = await withAIRetry(() => openai.chat.completions.create({
       model: "gpt-4o",
       messages: [
         {
@@ -159,7 +160,7 @@ export async function generateReleaseForm(talentName: string, roleName: string, 
           Include standard clauses for name & likeness rights in perpetuity, non-disclosure, and payment terms.`
         }
       ]
-    }, { timeout: 60000 });
+    }, { timeout: 60000 }));
 
     return response.choices[0]?.message?.content || "Contract generation failed.";
   } catch (error) {
@@ -182,7 +183,7 @@ export async function predictFatigue(scheduleDays: any[]): Promise<any> {
     
     Return a JSON object: { "warnings": [{ "day": number, "issue": "Description", "severity": "High|Medium|Low", "suggestion": "How to fix" }] }`;
 
-    const response = await openai.chat.completions.create({
+    const response = await withAIRetry(() => openai.chat.completions.create({
       model: "gpt-4o",
       response_format: { type: "json_object" },
       messages: [
@@ -195,7 +196,7 @@ export async function predictFatigue(scheduleDays: any[]): Promise<any> {
           content: prompt
         }
       ]
-    }, { timeout: 60000 });
+    }, { timeout: 60000 }));
 
     const content = response.choices[0]?.message?.content || '{"warnings": []}';
     let parsed;

--- a/server/ai-enhanced.ts
+++ b/server/ai-enhanced.ts
@@ -1,5 +1,6 @@
 import OpenAI from 'openai';
 import pdf from 'pdf-parse';
+import { withAIRetry } from './ai.js';
 
 // Initialize OpenAI client
 const openai = process.env.OPENAI_API_KEY ? new OpenAI({
@@ -241,7 +242,7 @@ Script text:
 ${scriptText.substring(0, 8000)} // Limit to avoid token limits
 `;
 
-    const completion = await openai.chat.completions.create({
+    const completion = await withAIRetry(() => openai.chat.completions.create({
       model: "gpt-4",
       messages: [
         {
@@ -255,7 +256,7 @@ ${scriptText.substring(0, 8000)} // Limit to avoid token limits
       ],
       temperature: 0.1,
       max_tokens: 4000
-    }, { timeout: 120000 });
+    }, { timeout: 120000 }));
 
     const response = completion.choices[0]?.message?.content;
     if (!response) {
@@ -489,7 +490,7 @@ Optimize for:
 8. Plan for weather dependencies
 `;
 
-    const completion = await openai.chat.completions.create({
+    const completion = await withAIRetry(() => openai.chat.completions.create({
       model: "gpt-4",
       messages: [
         {
@@ -503,7 +504,7 @@ Optimize for:
       ],
       temperature: 0.1,
       max_tokens: 3000
-    }, { timeout: 90000 });
+    }, { timeout: 90000 }));
 
     const response = completion.choices[0]?.message?.content;
     if (!response) {
@@ -602,7 +603,7 @@ Return JSON with:
 }
 `;
 
-    const completion = await openai.chat.completions.create({
+    const completion = await withAIRetry(() => openai.chat.completions.create({
       model: "gpt-4",
       messages: [
         {
@@ -616,7 +617,7 @@ Return JSON with:
       ],
       temperature: 0.7,
       max_tokens: 2500
-    }, { timeout: 60000 });
+    }, { timeout: 60000 }));
 
     const response = completion.choices[0]?.message?.content;
     if (!response) {
@@ -657,10 +658,10 @@ Return JSON with:
 async function getEmbedding(text: string): Promise<number[]> {
   if (!openai) return [];
   
-  const response = await openai.embeddings.create({
+  const response = await withAIRetry(() => openai.embeddings.create({
     model: "text-embedding-3-small",
     input: text
-  }, { timeout: 15000 });
+  }, { timeout: 15000 }));
   
   return response.data[0].embedding;
 }

--- a/server/ai.ts
+++ b/server/ai.ts
@@ -8,7 +8,7 @@ export const openai = process.env.OPENAI_API_KEY ? new OpenAI({
 }) : null;
 
 // AI Quality: Add exponential backoff retry logic for transient API failures
-async function withAIRetry<T>(
+export async function withAIRetry<T>(
   operation: () => Promise<T>,
   maxRetries: number = 3,
   baseDelay: number = 1000


### PR DESCRIPTION
🤖 Astra: Add retries to AI batch parallel calls

💡 What: Wrapped 7 unguarded `openai.chat.completions.create` and 1 `openai.embeddings.create` calls across `ai-advanced.ts` and `ai-enhanced.ts` in an existing `withAIRetry` utility.
🎯 Why: A single HTTP 429/500 failure inside a parallel batch array iteration (like embedding comparisons) instantly triggers a silent UI degradation/fallback, even if other calls succeeded.
📊 Impact: Eliminates silent failures from network timeouts or rate-limiting for critical user workflows.
🔬 Verification: Ran the full test suite locally. Spot-checked diff outputs.

---
*PR created automatically by Jules for task [7678323227493750771](https://jules.google.com/task/7678323227493750771) started by @lanryweezy*